### PR TITLE
Enable d3d8 backend in dxvk

### DIFF
--- a/org.winehq.Wine.DLLs.dxvk.yml
+++ b/org.winehq.Wine.DLLs.dxvk.yml
@@ -41,6 +41,7 @@ modules:
       - --buildtype=release
       - --strip
       - -Denable_dxgi=true
+      - -Denable_d3d8=true
       - -Denable_d3d9=true
       - -Denable_d3d10=true
       - -Denable_d3d11=true


### PR DESCRIPTION
Hi, I've enabled recently merged d3d8 backend and also removed compilation flag since it should be working fine as it's marked as fixed here https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
EDIT: Looks like it's not fixed, maybe mingw doesn't have it backported.