### PR TITLE
Update to 24.08

### DIFF
--- a/org.winehq.Wine.DLLs.dxvk.metainfo.xml
+++ b/org.winehq.Wine.DLLs.dxvk.metainfo.xml
@@ -13,12 +13,9 @@
   </description>
   <url type="homepage">https://github.com/doitsujin/dxvk/</url>
   <releases>
-    <release version="2.4.1" date="2024-09-26">
-      <description></description>
-    </release>
-    <release version="2.4" date="2024-07-10">
-      <description/>
-    </release>
+    <release version="2.6" date="2025-03-13"/>
+    <release version="2.4.1" date="2024-09-26"/>
+    <release version="2.4" date="2024-07-10"/>
     <release version="2.3.1" date="2024-03-20"/>
     <release version="2.3" date="2023-09-04"/>
     <release version="2.2" date="2023-05-12"/>

--- a/org.winehq.Wine.DLLs.dxvk.yml
+++ b/org.winehq.Wine.DLLs.dxvk.yml
@@ -15,7 +15,6 @@ build-options:
   cxxflags: -fno-stack-clash-protection
   ldflags: ''
   ldflags-override: true
-appstream-compose: false
 cleanup:
   - '*.a'
   - '*.la'
@@ -88,8 +87,6 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
-      - appstream-compose --basename=${FLATPAK_ID} --prefix=${FLATPAK_DEST} --origin=flatpak
-        ${FLATPAK_ID}
     sources:
       - type: file
         path: org.winehq.Wine.DLLs.dxvk.metainfo.xml

--- a/org.winehq.Wine.DLLs.dxvk.yml
+++ b/org.winehq.Wine.DLLs.dxvk.yml
@@ -1,8 +1,8 @@
 id: org.winehq.Wine.DLLs.dxvk
 build-extension: true
 runtime: org.winehq.Wine
-runtime-version: stable-23.08
-sdk: org.freedesktop.Sdk//23.08
+runtime-version: stable-24.08
+sdk: org.freedesktop.Sdk//24.08
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.mingw-w64
 build-options:
@@ -54,8 +54,8 @@ modules:
     sources: &dxvk-sources
       - type: git
         url: https://github.com/doitsujin/dxvk.git
-        tag: v2.4.1
-        commit: 0cf05780abd7250c2cd713b7749cf32180157cf5
+        tag: v2.6
+        commit: ad253b8a7e20b7cf16fce7d1c505928a434eac29
         x-checker-data:
           type: json
           url: https://api.github.com/repos/doitsujin/dxvk/releases/latest


### PR DESCRIPTION
Last year there was an issue with DXVK extension not working with Wine and other Flatpaks that utilize it. According to a [request](https://github.com/flathub/org.winehq.Wine/issues/119#issuecomment-2756921017), we would like to revive the DXVK extension and see if it will now work (or if not, whether something could be fixed about it).

I don't know how to create a new branch for 24.08.